### PR TITLE
fix package install from conda env.yml and update example in README

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -22,7 +22,7 @@ jobs:
           xargs -a apt.txt sudo apt-get install -y
         fi
         if test -f environment.yml; then
-          conda install --file environment.yml
+          conda env update --file local.yml
         fi
         if test -f requirements.txt; then
           pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Additional dependencies may be specified via `apt.txt`, `environment.yml`, and/o
 - `environment.yml`: passed to `conda install`, e.g.:
 
   ```yml
-  name: winning-submission
-  channels: [conda-forge, pytorch, nvidia]
+  channels:
+  - conda-forge
+  - pytorch
+  - nvidia
   dependencies:
   - cupy
   - cuda-version =11.8


### PR DESCRIPTION
Installation of packages via conda from an `environment.yaml` was wrong creating errors.

`conda env update` should be used and the name in `environment.yaml`  should not contain a name